### PR TITLE
Improve documentation and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# Early-Stopping
+# Early Stopping for Iterative Learning
+
+This repository provides reference implementations of early stopping strategies for iterative algorithms such as Landweber iterations, conjugate gradients, L2 boosting, truncated SVD and regression trees. The project originates from academic work on implicit regularisation for inverse problems and is designed for experimentation and teaching.
+
+## Features
+
+- Landweber iterations with bias/variance tracking
+- Conjugate Gradients and L2 boosting with discrepancy-based stopping rules
+- Utilities for truncated SVD and regression trees
+- A simulation wrapper to reproduce experiments
+
+## Requirements
+
+The library targets Python 3.7+ and relies on common scientific packages:
+
+- `numpy`
+- `scipy`
+- `scikit-learn`
+
+## Installation
+
+```bash
+git clone https://github.com/TarekDjaker/Early-Stopping.git
+cd Early-Stopping
+pip install -e .
+```
+
+## Quick start
+
+Execute the example script to see a minimal Landweber run on synthetic data:
+
+```bash
+python example.py
+```
+
+If NumPy is unavailable the script prints a short message instead of raising an error. With the dependency installed it reports the iteration at which the discrepancy principle triggers early stopping.
+
+## Documentation
+
+Further theoretical background and API details can be found in the [project documentation](https://earlystop.github.io/EarlyStopping/).
+
+## License
+
+This project is released under the [MIT License](LICENSE).
+

--- a/__init__.py
+++ b/__init__.py
@@ -1,10 +1,7 @@
-from .example import add_one   # '.' needed since python3
 from .L2_boost import L2_boost
 from .conjugate_gradients import ConjugateGradients
 from .landweber import Landweber
-from .simulation_wrapper import SimulationWrapper
-from .simulation_wrapper import SimulationParameters
-from .simulation_wrapper import SimulationData
+from .simulation_wrapper import SimulationWrapper, SimulationParameters, SimulationData
 from .truncated_svd import TruncatedSVD
 from .regression_tree import RegressionTree
 

--- a/example.py
+++ b/example.py
@@ -1,2 +1,40 @@
-def add_one(number):
-    return number + 1
+"""Executable example for the Landweber early-stopping algorithm."""
+
+try:
+    import numpy as np
+    from landweber import Landweber
+except ModuleNotFoundError:  # pragma: no cover - handled gracefully at runtime
+    np = None
+    Landweber = None
+
+
+def main() -> None:
+    """Run a small Landweber demo on synthetic data."""
+
+    if np is None or Landweber is None:  # dependency guard for offline environments
+        print("NumPy is required to run this example. Please install it and retry.")
+        return
+
+    rng = np.random.default_rng(0)
+    design = rng.normal(size=(100, 20))
+    true_signal = rng.normal(size=20)
+    noise_level = 0.1
+    response = design @ true_signal + noise_level * rng.normal(size=100)
+
+    lw = Landweber(
+        design=design,
+        response=response,
+        learning_rate=0.5,
+        true_signal=true_signal,
+        true_noise_level=noise_level,
+    )
+    lw.iterate(number_of_iterations=50)
+    stop = lw.get_discrepancy_stop(
+        critical_value=noise_level**2 * design.shape[0], max_iteration=50
+    )
+    print(f"Discrepancy principle stop: {stop} iterations")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,11 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 license = "MIT"  # ✅ Use SPDX identifier only
+dependencies = [
+    "numpy",
+    "scipy",
+    "scikit-learn",
+]
 
 [project.urls]
 Homepage = "https://github.com/EarlyStop/EarlyStopping"


### PR DESCRIPTION
## Summary
- list core dependencies in `pyproject.toml` and README
- make `example.py` exit gracefully when NumPy (and thus Landweber) isn't installed

## Testing
- `python example.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a77b94d1a4832c8e9db537392c1acf